### PR TITLE
Fix conversion list request content-type

### DIFF
--- a/Slack.NetStandard/WebApi/ConversationsApi.cs
+++ b/Slack.NetStandard/WebApi/ConversationsApi.cs
@@ -120,7 +120,7 @@ namespace Slack.NetStandard.WebApi
 
         public Task<ChannelListResponse> List(ConversationListRequest request)
         {
-            return _client.MakeJsonCall<ConversationListRequest, ChannelListResponse>("conversations.list", request);
+            return _client.MakeUrlEncodedCall<ChannelListResponse>("conversations.list", request);
         }
 
         public Task<ConversationMembersResponse> Members(string channel)


### PR DESCRIPTION
The content type required by conversations.history is `application/x-www-form-urlencoded` .

https://api.slack.com/methods/conversations.list

related https://github.com/stoiveyp/Slack.NetStandard/pull/15